### PR TITLE
Add alt/opt as a second way to increment by .1

### DIFF
--- a/incrementable.js
+++ b/incrementable.js
@@ -21,7 +21,7 @@ var _ = window.Incrementable = function(textField, multiplier, units) {
 
 	this.multiplier = multiplier || function(evt) {
 		if (evt.shiftKey) { return 10; }
-		
+		if (evt.altKey) { return .1; }
 		if (evt.ctrlKey) { return .1; }
 		
 		return 1;


### PR DESCRIPTION
I typically use the Alt/Opt key to increment by .1 units in Chrome/FF devtools. This branch supports both Ctrl and Alt/Opt :confetti_ball: 

I applied this to my fork of your repo for easy testing: http://rupl.github.io/incrementable/
